### PR TITLE
global object consistency

### DIFF
--- a/lib/xde.js
+++ b/lib/xde.js
@@ -95,11 +95,11 @@
     };
 
     xde._reset();
-    events.add(window, 'message', onMessage, false);
+    events.add(win, 'message', onMessage, false);
 
     if(typeof exports === 'object') {
         module.exports = xde;
     } else {
         win.xde = xde;
     }
-})(this, this.eventListener || require('eventlistener'));
+})(this.window || (typeof global !== "undefined" ? global : this), this.eventListener || require('eventlistener'));


### PR DESCRIPTION
Just to keep naming consistent. Also, it screws up my tests if I'm mocking global object in environment without DOM.
